### PR TITLE
standalone docker container and README updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,25 @@
+# syntax=docker/dockerfile:1
+
 # choose a base image, we use a lightweight docker container running python3 on ubuntu
 FROM --platform=linux/amd64 python:3.7
 # had to specify python version because 3.10 isn't compatible with packages, and is the default
 
+# Maybe this can be tensorflow in the future to support Coral TPUs?
+ENV DGLBACKEND=pytorch
+
 # install basic packages
 RUN apt-get update
 RUN apt-get install -y tmux wget curl git nano
-RUN apt-get install ffmpeg libsm6 libxext6  -y 
+RUN apt-get install -y ffmpeg libsm6 libxext6
 # Added above line because (https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo)
-# RUN apt-get install -y pip
+
 # copy the current repository to the container and store it at /usr/src/app - you can learn more about this convention here: https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout
-COPY . /usr/src/app
+COPY . /usr/src/app/
+
 # install the dependencies
 RUN pip install -r /usr/src/app/requirements.txt 
-# open a shell when launching the container
-CMD ["bash"] 
+
+EXPOSE 8000
+
+WORKDIR /usr/src/app
+CMD ["/bin/bash", "-c", "uvicorn tileImageAndCorrect:app --reload --host \"0.0.0.0\" --port 8000"] 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,27 @@ Run the app locally with: `uvicorn tileImageAndCorrect:app --reload --host "0.0.
 1. Clone this repository
 1. Inside the directory for this repository, run:
 
+    ```shell
     docker build -t pathology-image-tiling-and-correction
+    ```
 
 ## Running the container
 Run the app in Docker via:
 
     docker run -d -p 8000:8000 pathology-image-tiling-and-correction:latest
+
+and it should be running at http://localhost:8000 (or replace `localhost` with the IP/DNS name of whichever computer is running the container)
+
+## Processing data with Postman
+
+1. In Postman, craft a request with the following properties:
+    | Postman parameter | Value |
+    | --- | --- |
+    | Request Type | `POST` |
+    | Body Type | `form-data` |
+    | key type (dropdown) | File |
+    | key name (textbox) | `files` |
+    | key value | (select an image) |
+  
+1. Press the "Send" button
+1. The result should be a .zip file, so when the result is ready (it will look like random letters and numbers in the bottom half of the screen), press "Save Response" on the right side of the screen. Save the zip file.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # pathology-image-tiling-and-correction
 
-Run with: `uvicorn tileImageAndCorrect:app --reload --host "0.0.0.0"`
+## Running this app locally
+Run the app locally with: `uvicorn tileImageAndCorrect:app --reload --host "0.0.0.0"`
+
+## Building the container image
+
+1. Clone this repository
+1. Inside the directory for this repository, run:
+
+    docker build -t pathology-image-tiling-and-correction
+
+## Running the container
+Run the app in Docker via:
+
+    docker run -d -p 8000:8000 pathology-image-tiling-and-correction:latest

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run the app locally with: `uvicorn tileImageAndCorrect:app --reload --host "0.0.
 1. Inside the directory for this repository, run:
 
     ```shell
-    docker build -t pathology-image-tiling-and-correction
+    docker build -t pathology-image-tiling-and-correction .
     ```
 
 ## Running the container
@@ -22,6 +22,7 @@ and it should be running at http://localhost:8000 (or replace `localhost` with t
 ## Processing data with Postman
 
 1. In Postman, craft a request with the following properties:
+
     | Postman parameter | Value |
     | --- | --- |
     | Request Type | `POST` |


### PR DESCRIPTION
change the Dockerfile so that it can generate a standalone docker container that can run on servers

Future task: make the port number configurable

Also update the README to explain how to use the docker container